### PR TITLE
[1.3.6]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.3.6](https://github.com/network-international/ngenius-woocommerce-plugin/releases/tag/1.3.6)
+
+### Fixed
+
+- **Cache Key Fix**: Fixed cache key collision issue in order recovery flow that was causing declined payment
+  re-attempts to fail on some servers with longer cache timeouts. Orders now properly update from failed to successful
+  status after recovery transactions.
+
 ## [1.3.5](https://github.com/network-international/ngenius-woocommerce-plugin/releases/tag/1.3.5)
 
 ### Fixed
@@ -9,9 +17,11 @@
 ## [1.3.4](https://github.com/network-international/ngenius-woocommerce-plugin/releases/tag/1.3.4)
 
 ### Added
+
 - Added PHP 7.4 support.
 
 ### Changed
+
 - Refactored `add_settings_error` to use WordPress Settings API; removed direct `$wp_settings_errors` manipulation.
 - JS block registration now handles missing/undefined server data in `index.js`.
 - Synced `package.json` version with PHP plugin version.
@@ -23,36 +33,48 @@
 
 ### Fixed
 
-- **Composer Version Issue**: This is a fix for an issue identified in automated testing, as it corrects a problem with the Composer version to ensure compatibility.
+- **Composer Version Issue**: This is a fix for an issue identified in automated testing, as it corrects a problem with
+  the Composer version to ensure compatibility.
 
 ### Added
 
-- **WooCommerce Active Check**: The addition of programmatic checks to verify WooCommerce is active and admin-side notifications are new features or functionalities introduced to the plugin.
+- **WooCommerce Active Check**: The addition of programmatic checks to verify WooCommerce is active and admin-side
+  notifications are new features or functionalities introduced to the plugin.
 
 ### Changed
 
-- **Logging Configuration**: Disabling logging by default modifies an existing behavior to align with data privacy best practices.
+- **Logging Configuration**: Disabling logging by default modifies an existing behavior to align with data privacy best
+  practices.
 
 ## [1.3.2](https://github.com/network-international/ngenius-woocommerce-plugin/releases/tag/1.3.2)
 
 ### Added
 
-- Onboarding Link in Plugin Interface: Added an accessible link within the WooCommerce plugin interface that redirects merchants to the onboarding site for e-commerce payment solutions. The link is prominently placed in the plugin's settings panel, ensuring easy access for merchants to initiate the onboarding process.
+- Onboarding Link in Plugin Interface: Added an accessible link within the WooCommerce plugin interface that redirects
+  merchants to the onboarding site for e-commerce payment solutions. The link is prominently placed in the plugin's
+  settings panel, ensuring easy access for merchants to initiate the onboarding process.
 
 ## [1.3.1](https://github.com/network-international/ngenius-woocommerce-plugin/releases/tag/1.3.1)
 
 ### Changed
+
 - **CSS Improvements**: Adjusted payment icon styling for better compatibility with classic checkout themes.
 
 ## [1.3.0](https://github.com/network-international/ngenius-woocommerce-plugin/releases/tag/1.3.0)
 
 ### Added
-- **Manual Payment Links**: Added functionality to generate and manage manual payment links for enhanced flexibility in transaction processing.
-- **Updated Branding**: Replaced outdated Network logo with the latest version for consistent branding across the plugin.
-- **Dependency Validation**: Implemented automatic checks for international dependencies to ensure seamless compatibility and installation.
+
+- **Manual Payment Links**: Added functionality to generate and manage manual payment links for enhanced flexibility in
+  transaction processing.
+- **Updated Branding**: Replaced outdated Network logo with the latest version for consistent branding across the
+  plugin.
+- **Dependency Validation**: Implemented automatic checks for international dependencies to ensure seamless
+  compatibility and installation.
 
 ### Fixed
-- **Transaction Handling**: Resolved an issue where N-Genius transactions were occasionally missing from orders, improving reliability.
+
+- **Transaction Handling**: Resolved an issue where N-Genius transactions were occasionally missing from orders,
+  improving reliability.
 - **Minor Bug Fixes**: Addressed various small bugs to enhance overall stability and user experience.
 
 ## [1.2.0](https://github.com/network-international/ngenius-woocommerce-plugin/releases/tag/1.2.0)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 ## Prerequisites
 
-**PHP intl** - Ensure the [PHP intl](https://www.php.net/manual/en/intl.installation.php) extension is installed and enabled on your server.
+**PHP intl** - Ensure the [PHP intl](https://www.php.net/manual/en/intl.installation.php) extension is installed and
+enabled on your server.
 
 ## Installation
 

--- a/ngenius/changelog.txt
+++ b/ngenius/changelog.txt
@@ -1,5 +1,8 @@
 *** N-Genius Online by Network Changelog ***
 
+= 1.3.6 - 2026-02-04 =
+ * Cache Key Fix: Fixed cache key collision issue in order recovery flow that was causing declined payment re-attempts to fail on some servers with longer cache timeouts. Orders now properly update from failed to successful status after recovery transactions.
+
 = 1.3.5 - 2025-12-18 =
  * Fatal Memory Error: Fixed an infinite loop in the WC logger affecting some sites.
 

--- a/ngenius/gateway/class-network-international-ngenius-gateway.php
+++ b/ngenius/gateway/class-network-international-ngenius-gateway.php
@@ -515,7 +515,6 @@ class NetworkInternationalNgeniusGateway extends NetworkInternationalNgeniusAbst
         global $wp_session;
 
         $order_id  = $order->get_id();
-        $cache_key = 'ngenius_order_' . $order_id;
 
         // Check if wp_session exists and has ngenius data
         $ngenius_session_data = [];
@@ -524,6 +523,8 @@ class NetworkInternationalNgeniusGateway extends NetworkInternationalNgeniusAbst
         } else {
             $this->log('Missing or incomplete wp_session data for order: ' . $order_id, 'warning');
         }
+
+        $cache_key = 'ngenius_order_' . $ngenius_session_data['reference'] ?? $order_id;
 
         // Prepare the data to be saved
         $data = array_merge(

--- a/ngenius/ngenius.php
+++ b/ngenius/ngenius.php
@@ -5,7 +5,7 @@
  * Description: Receive payments using the Network International Payment Solutions payments provider.
  * Author: Network International
  * Author URI: https://www.network.ae/en
- * Version: 1.3.5
+ * Version: 1.3.6
  * Requires at least: 6.0
  * Requires PHP: 8.0
  * Tested up to: 6.8.2
@@ -46,7 +46,7 @@ require_once "$f/vendor/autoload.php";
 use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
 use Ngenius\NgeniusCommon\NgeniusOrderStatuses;
 
-define('NETWORK_INTERNATIONAL_NGENIUS_VERSION', '1.3.5'); // WRCS: DEFINED_VERSION.
+define('NETWORK_INTERNATIONAL_NGENIUS_VERSION', '1.3.6'); // WRCS: DEFINED_VERSION.
 define(
     'NETWORK_INTERNATIONAL_NGENIUS_URL',
     untrailingslashit(plugins_url(basename(plugin_dir_path(__FILE__)), basename(__FILE__)))

--- a/ngenius/readme.txt
+++ b/ngenius/readme.txt
@@ -4,7 +4,7 @@ Tags: ecommerce, e-commerce, woocommerce, N-Genius, N-Genius by Network
 Requires at least: 6.0
 Tested up to: 6.8
 Requires PHP: 8.0
-Stable tag: 1.3.5
+Stable tag: 1.3.6
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -22,6 +22,9 @@ We provide a secure checkout experience for your shoppers, knowing that intellig
 Should you wish to, you may compile the WooCommerce Blocks Support <a href="https://github.com/network-international/ngenius-woocommerce-plugin?tab=readme-ov-file#compile-woocommerce-blocks-support-from-source">directly from source</a>.
 
 == Changelog ==
+= 1.3.6 - 2026-02-04 =
+ * Cache Key Fix: Fixed cache key collision issue in order recovery flow that was causing declined payment re-attempts to fail on some servers with longer cache timeouts. Orders now properly update from failed to successful status after recovery transactions.
+
 = 1.3.5 - 2025-12-18 =
  * Fatal Memory Error: Fixed an infinite loop in the WC logger affecting some sites.
 


### PR DESCRIPTION
### Fixed

- **Cache Key Fix**: Fixed cache key collision issue in order recovery flow that was causing declined payment re-attempts to fail on some servers with longer cache timeouts. Orders now properly update from failed to successful status after recovery transactions.